### PR TITLE
v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # homebridge-config-backup.sh
 This is a bash script that allows you to automate local backup of *config.json* of a Homebridge instance runing inside a Docker container.
 
-With v1.2.0, this script implements unix-like commands usage, so if you want to use a working directory different from default one, you must use ***-d*** option along with the path to that directory.
+With v1.2.0, this script implements unix-like command structure, so if you want to use a working directory different from default one, you must use ***-d*** option along with the path to that directory.
 
 Things to do after dowloading script
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # homebridge-config-backup.sh
 This is a bash script that allows you to automate local backup of *config.json* of a Homebridge instance runing inside a Docker container.
 
+With v1.2.0, this script implements unix-like commands usage, so if you want to use a working directory different from default one, you must use ***-d*** option along with the path to that directory.
+
 Things to do after dowloading script
 
-- Edit the script and replace *HOMEBRIDGE_BACKUP_DIR* variable with the location where you want the backups to be stored
 - Make shell script executable runing "chmod u+x homebridge-config-backup.sh"
-- Edit cron with "crontab -e" command and add the subsequent line at the end, replacing *<abs_path>* with the location where you stored *homebridge-config-backup.sh*
+- Edit cron with "crontab -e" command and add the subsequent line at the end, replacing *<abs_path>* with the location where you stored *homebridge-config-backup.sh*, and *<working_directory>* with the directory where backups will be stored, without *$HOME* path.
 
-  >  0,15,30,45 * * * * bash /<abs_path>/homebridge-config-backup.sh
+  >  0 * * * * bash /<abs_path>/homebridge-config-backup.sh -d <working_directory>
   
 - Save cron using Ctrl-O
 - Exit editor with Ctrl-X
 - Reboot so changes take effect
 
-The cron example will run the script every 15 minutes. The script will attempt to copy *config.json* from Homebridge docker container to local storage, check if md5sum of copied file and existing backup are equal or different. If md5sum is different, the script will create a backup including md5sum in the name of the file, and write down the result of the task on a log file, so you can check the timeline of all the backups.
+The cron example will run the script every hour. The script will attempt to copy *config.json* from Homebridge docker container to local storage, check if md5sum of copied file and existing backup are equal or different. If md5sum is different, the script will create a backup including md5sum in the name of the file, and write down the result of the task on a log file, so you can check the timeline of all the backups.
 
 Obviously you can change the time interval at wich the script runs modifying the cron command. I recomend https://crontab.guru to do that.

--- a/homebridge-config-backup.sh
+++ b/homebridge-config-backup.sh
@@ -40,6 +40,7 @@ if [[ $1 == "--help" || $1 == "-h" ]]
     echo ""
     echo "AUTHOR:"
     echo "    Written by Edison Montes M."
+    echo "    <https://github.com/Geek-MD/homebridge-config-backup>"
     echo ""
     echo "COPYRIGHT:"
     echo "    MIT License <https://github.com/Geek-MD/homebridge-config-backup/blob/main/LICENSE>."
@@ -62,6 +63,7 @@ if [[ $1 == "--version" || $1 == "-v" ]]
     echo "There is NO WARRANTY, to the extent permitted by law."
     echo ""
     echo "Written by Edison Montes M."
+    echo "<https://github.com/Geek-MD/homebridge-config-backup>"
     exit 0
 fi
 


### PR DESCRIPTION
- Implementation of unix-like command structure, with options and arguments.
  - -d is used to specify a working directory for config backups. You must provide directory as the argument, excluding $HOME path.
  - -l is used to specify a limit for the amount of backup files that will be kept. You must provide an integer as the argument.
  - -v output script version and author information.
  - -h output script help.